### PR TITLE
Add CSS Standard Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # postcss-apply
 
+[![CSS Standard Status][css-image]][css-url]
 [![npm version][npm-image]][npm-url]
 [![Build Status][travis-image]][travis-url]
 [![Coverage Status][codecov-image]][codecov-url]
@@ -141,6 +142,8 @@ postcss-apply is [unlicensed](http://unlicense.org/).
 
 [PostCSS]: https://github.com/postcss/postcss
 
+[css-url]: https://jonathantneal.github.io/css-db/#css-apply-rule
+[css-image]: https://jonathantneal.github.io/css-db/badge/css-apply-rule.svg
 [npm-url]: https://www.npmjs.org/package/postcss-apply
 [npm-image]: http://img.shields.io/npm/v/postcss-apply.svg?style=flat-square
 [travis-url]: https://travis-ci.org/pascalduez/postcss-apply?branch=master


### PR DESCRIPTION
Hey there. I’m just trying to get the word out that cssdb has badges to help users know the status of your CSS polyfill.

[cssdb](https://jonathantneal.github.io/css-db/) is a list I’m compiling of CSS features and their positions in the process of becoming implemented web standards.

This is especially sensitive with this plugin, as you’ve noted the platform status in a blockquote.