### PR TITLE
Allow an options set to be a string as well as an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ default: `false`
 Allows for keeping resolved declarations and `@apply` rules alongside.
 
 ### `sets`  
-type: `Object`  
+type: `{ [customPropertyName]: Object | String }`  
 default: `{}`  
 Allows you to pass an object of custom property sets for `:root`.
-These definitions will be prepended, in such overriden by the one declared in CSS if they share the same name.
+These definitions will be prepended, in such overridden by the one declared in CSS if they share the same name.
 The keys are automatically prefixed with the CSS `--` to make it easier to share sets in your codebase.
 
 

--- a/src/visitor.js
+++ b/src/visitor.js
@@ -67,11 +67,21 @@ export default class Visitor {
       const newRule: Rule = postcss.rule({ selector: `--${setName}` });
 
       // $FlowFixMe
-      Object.entries(sets[setName]).forEach(([prop, value]) => {
-        newRule.prepend(
-          postcss.decl({ prop: kebabify(prop), value })
+      const set = sets[setName];
+
+      if (typeof set === 'string') {
+        newRule.prepend(set);
+      } else if (typeof set === 'object') {
+        Object.entries(set).forEach(([prop, value]) => {
+          newRule.prepend(
+            postcss.decl({ prop: kebabify(prop), value })
+          );
+        });
+      } else {
+        throw new Error(
+          `Unrecognized set type \`${typeof set}\`, must be an object or string.`
         );
-      });
+      }
 
       this.cache[setName] = newRule;
     });

--- a/test/__snapshots__/prepend.spec.js.snap
+++ b/test/__snapshots__/prepend.spec.js.snap
@@ -13,10 +13,19 @@ exports[`prepend should override sets from options with CSS declared ones 1`] = 
 }"
 `;
 
-exports[`prepend should prepend sets from options 1`] = `
+exports[`prepend should prepend sets from options for a object set 1`] = `
 ".dummy {
   color: tomato;
   font-size: 1.4rem;
   padding: 0 1rem;
+}"
+`;
+
+exports[`prepend should prepend sets from options for a string set 1`] = `
+".dummy {
+  fontSize: 1.4rem;
+          @media (width >= 500px) {
+  fontSize: 2.4rem;
+          }
 }"
 `;

--- a/test/prepend.spec.js
+++ b/test/prepend.spec.js
@@ -4,26 +4,73 @@ import plugin from '../src';
 
 
 describe('prepend', () => {
-  it('should prepend sets from options', async () => {
-    const input = stripIndent`
-      .dummy {
-        @apply --justatest;
-      }
-    `;
+  describe('should prepend sets from options', () => {
+    it('for a object set', async () => {
+      const input = stripIndent`
+        .dummy {
+          @apply --justatest;
+        }
+      `;
 
-    const sets = {
-      justatest: {
-        padding: '0 1rem',
-        fontSize: '1.4rem',
-        color: 'tomato',
-      },
-    };
+      const sets = {
+        justatest: {
+          padding: '0 1rem',
+          fontSize: '1.4rem',
+          color: 'tomato',
+        },
+      };
 
-    const result = await postcss()
-      .use(plugin({ sets }))
-      .process(input);
+      const result = await postcss()
+        .use(plugin({ sets }))
+        .process(input);
 
-    expect(result.css).toMatchSnapshot();
+      expect(result.css).toMatchSnapshot();
+    });
+
+    it('for a string set', async () => {
+      const input = stripIndent`
+        .dummy {
+          @apply --justatest;
+        }
+      `;
+
+      const sets = {
+        justatest: `
+          fontSize: 1.4rem;
+
+          @media (width >= 500px) {
+            fontSize: 2.4rem;
+          }
+        `,
+      };
+
+      const result = await postcss()
+        .use(plugin({ sets }))
+        .process(input);
+
+      expect(result.css).toMatchSnapshot();
+    });
+
+    it('throws if the set is not an object or a string', async () => {
+      const input = stripIndent`
+        .dummy {
+          @apply --justatest;
+        }
+      `;
+
+      const sets = {
+        justatest: () => {},
+      };
+
+      expect(() => {
+        postcss() // eslint-disable-line no-unused-expressions
+         .use(plugin({ sets }))
+         .process(input)
+         .css;
+      }).toThrowError(
+        'Unrecognized set type `function`, must be an object or string.'
+      );
+    });
   });
 
   it('should override sets from options with CSS declared ones', async () => {


### PR DESCRIPTION
Hi. I wanted to be able to support more complex set option definitions at my company. For [example](https://github.com/DomainGroupOSS/create-react-app/blob/domain-react-scripts/packages/react-scripts/config/webpack.config.dev.js#L53-L75):

```javascript
{
  sets: {
    'font-h1': `
      font-size: var(--h1-mobile-font-size);
      line-height: var(--h1-mobile-line-height);

      @media (--tablet-min-width) {
        font-size: var(--h1-font-size);
        line-height: var(--h1-line-height);
      }
    `,
    'a-normalize': `
      color: inherit;
      text-decoration: inherit;

      &:hover,
      &:focus,
      &:visited,
      &:active {
        color: inherit;
        text-decoration: inherit;
      }
    `,
  }
}
```

I see this is supported in the consumers style sheet:

![screen shot 2018-03-02 at 12 11 48 pm](https://user-images.githubusercontent.com/2787876/36878486-52e47038-1e13-11e8-8ff9-9503e7547c5a.png)

The code does a type check on the set and passes a string to [Root#prepend](http://api.postcss.org/Root.html#prepend) instead.

